### PR TITLE
Reset non-closed circuitbreaker upon success

### DIFF
--- a/circuitbreaker.go
+++ b/circuitbreaker.go
@@ -302,7 +302,7 @@ func (cb *Breaker) Success() {
 	cb.backoffLock.Unlock()
 
 	state := cb.state()
-	if state == halfopen {
+	if state != closed {
 		cb.Reset()
 	}
 	atomic.StoreInt64(&cb.consecFailures, 0)


### PR DESCRIPTION
Even if a circuitbreaker is currently open, a success indicates that it
should be reset back to closed. This is what appears to have been
intended, it just looks like the original author didn't consider rare
race conditions in which a success could be achieved while the breaker
was open.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/circuitbreaker/2)
<!-- Reviewable:end -->
