### PR TITLE
move BreakerReady event to Debugf, clarify event logging

### DIFF
--- a/circuitbreaker.go
+++ b/circuitbreaker.go
@@ -432,10 +432,10 @@ func (cb *Breaker) logEvent(event BreakerEvent) {
 		return
 	}
 	switch event {
-	case BreakerTripped, BreakerReset, BreakerReady:
-		cb.logger.Infof("circuitbreaker: %v %v", cb.name, event)
+	case BreakerTripped, BreakerReset:
+		cb.logger.Infof("circuitbreaker: %v event: %v", cb.name, event)
 	default:
-		cb.logger.Debugf("circuitbreaker: %v %v", cb.name, event)
+		cb.logger.Debugf("circuitbreaker: %v event: %v", cb.name, event)
 	}
 }
 


### PR DESCRIPTION
BreakerReady events happen regularly and thus logging them at Infof is too
noisy. Also, now that there is more logging than just events, add some more
structure to the event log message. After this is merged, I'll update https://github.com/cockroachdb/cockroach/pull/33676 to adopt it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/circuitbreaker/6)
<!-- Reviewable:end -->
